### PR TITLE
Catching errors and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ WAAFLE bundles two utilities, `waafle_junctions` and `waafle_qc`, that can be us
 A sample call to `waafle_junctions` looks like:
 
 ```
-$ waafle_qc \
+$ waafle_junctions \
   contigs.fna \
   contigs.gff \
   --reads1 contigs_reads.1.fq \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ An individual WAAFLE run requires one or two non-fixed inputs: 1) a file contain
 
 Contigs should be provided as nucleotide sequences in FASTA format. Contigs are expected to have unique, BLAST-compatible headers. WAAFLE is optimized for working with fragmentary contigs from partially assembled metagenomes (spanning 2-20 genes, or roughly 1-20 kb). WAAFLE is not optimized to work with extremely long contigs (100s of kbs), scaffolds, or closed genomes. The WAAFLE developers recommend [MEGAHIT](https://github.com/voutcn/megahit) as a general-purpose metagenomic assembler.
 
-* [A sample contigs input file](https://github.com/biobakery/waafle/blob/master/demo/input/demo_contigs.fna)
+* [A sample contigs input file](https://raw.githubusercontent.com/biobakery/waafle/refs/heads/main/demo/input/demo_contigs.fna)
 
 ### Input ORF calls (optional)
 

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,16 @@ setuptools.setup(
     long_description_content_type = "text/markdown",
     url = "https://huttenhower.sph.harvard.edu/waafle",
     packages = setuptools.find_packages( ),
+    keywords=['microbial','microbiome','bioinformatics','microbiology','metagenomic','metatranscriptomic','waafle'],
+    platforms=['Linux','MacOS'],
     classifiers = [
         "Programming Language :: Python",
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "Operating System :: MacOS",
+        "Operating System :: Unix",
+        "Programming Language :: Python :: 3.4",
+        "Topic :: Scientific/Engineering :: Bio-Informatics"
     ],
     entry_points = {
         "console_scripts": [

--- a/waafle/utils.py
+++ b/waafle/utils.py
@@ -33,6 +33,7 @@ import csv
 import re
 import gzip
 import bz2
+import subprocess
 from collections import OrderedDict
 
 import numpy as np
@@ -42,6 +43,23 @@ import numpy as np
 # GENERIC HELPER CLASSES / FUNCTIONS
 # ---------------------------------------------------------------
 # ---------------------------------------------------------------
+
+def run_process ( command ):
+    # Run a command line process and report final status on stdout
+    say( "Executing command:", command )
+    try:
+        stdout=subprocess.check_output( command, shell=True, stderr=subprocess.STDOUT).decode("utf-8")
+        say(stdout)
+        if "warning" in stdout.lower():
+            say("\nFinished with warnings.")
+        # Allow for the case where the program does not indicate a return code error
+        # and instead just reports the error in stdout/stderr
+        elif "error" in stdout.lower():
+            say("\nFinished with errors.")
+        else:
+            say( "\nFinished successfully." )
+    except (subprocess.CalledProcessError, EnvironmentError):
+        say("\nFinished with errors.")
 
 def say( *args ):
     print( " ".join( map( str, args ) ), file=sys.stderr )

--- a/waafle/utils.py
+++ b/waafle/utils.py
@@ -44,22 +44,29 @@ import numpy as np
 # ---------------------------------------------------------------
 # ---------------------------------------------------------------
 
-def run_process ( command ):
+def run_process ( command, success_message="\nFinished successfully."):
     # Run a command line process and report final status on stdout
+    issues=0
     say( "Executing command:", command )
     try:
         stdout=subprocess.check_output( command, shell=True, stderr=subprocess.STDOUT).decode("utf-8")
         say(stdout)
         if "warning" in stdout.lower():
             say("\nFinished with warnings.")
+            issues+=1
         # Allow for the case where the program does not indicate a return code error
         # and instead just reports the error in stdout/stderr
         elif "error" in stdout.lower():
             say("\nFinished with errors.")
+            issues+=1
         else:
-            say( "\nFinished successfully." )
+            say( success_message )
     except (subprocess.CalledProcessError, EnvironmentError):
         say("\nFinished with errors.")
+        issues+=1
+
+    return issues
+
 
 def say( *args ):
     print( " ".join( map( str, args ) ), file=sys.stderr )

--- a/waafle/waafle_junctions.py
+++ b/waafle/waafle_junctions.py
@@ -211,9 +211,8 @@ def bowtie2_build( p_bowtie2_build=None, p_contigs=None, p_index=None,
             ]
         command = " ".join( command )
         command = command.format( **alias )
-        os.system( command )
-        wu.say( "Build complete." )
-    return None
+        issues = wu.run_process( command , success_message="Build complete.")
+    return issues
 
 def bowtie2_align( p_bowtie2=None, p_reads1=None, p_reads2=None, 
                    p_index=None, p_sam=None, args=None, ):
@@ -241,9 +240,8 @@ def bowtie2_align( p_bowtie2=None, p_reads1=None, p_reads2=None,
             ]
         command = " ".join( command )
         command = command.format( **alias )
-        os.system( command )
-        wu.say( "Alignment complete." )
-    return None
+        issues = wu.run_process( command , success_message="Alignment complete.")
+    return issues
 
 # ---------------------------------------------------------------
 # utils for parsing SAM/GFF comparison
@@ -389,19 +387,22 @@ def main( ):
     p_junctions = wu.name2path( basename, p_outdir, ".junctions.tsv" )
 
     # alignment workflow
+    issues=0
     if args.sam is not None:
         p_sam = args.sam
         wu.say( "Using specified SAM file:", p_sam )
     elif args.reads1 is not None and args.reads2 is not None:
         # build process
-        bowtie2_build( 
+        wu.say("Running bowtie2 build.")
+        issues+=bowtie2_build( 
             p_bowtie2_build=args.bowtie2_build,
             p_contigs=args.contigs,
             p_index=p_index,
             args=args,
             )
         # alignment process
-        bowtie2_align(
+        wu.say("Running bowtie2 align.")
+        issues+=bowtie2_align(
             p_bowtie2=args.bowtie2,
             p_reads1=args.reads1, 
             p_reads2=args.reads2,
@@ -480,7 +481,10 @@ def main( ):
                     file=fh, )
 
     # end
-    wu.say( "Finished successfully." )
+    if issues == 0:
+        wu.say( "Finished successfully." )
+    else:
+        wu.say( "Finished with errors." )
 
 if __name__ == "__main__":
     main( )

--- a/waafle/waafle_search.py
+++ b/waafle/waafle_search.py
@@ -110,9 +110,7 @@ def main( ):
         "-outfmt \'{FORMAT}\'",
         ]
     command = " ".join( command ).format( **params )
-    wu.say( "Executing command:", command )
-    os.system( command )
-    wu.say( "Finished successfully." )
+    wu.run_process(command)
 
 if __name__ == "__main__":
     main( )


### PR DESCRIPTION
This PR addresses part of the feedback on the software during the manuscript review. This catches errors from subprocesses, replacing `os.system` with `subprocess.check_output` which allows for detection of warnings and errors that might be printed just to stdout and not returned as an error code.

This PR also contains two small modifications to the README identified in testing. The first is the demo file URL is changed to a raw link so the user can easily download the file for testing. The second is a change in a command from one executable to another. I am including this as an add on to this PR to reduce the overall numbers of PR. 

Please let me know if you have any questions! I did test everything I could with the demo input files. I could not find demo read files to test the waafle_junctions executable so I was only able to test on error conditions and not on a pass.

Thank you!